### PR TITLE
allow :assign_daily_occurrences to be triggerred manually

### DIFF
--- a/lib/mongoid_occurrence_views/event/occurrence.rb
+++ b/lib/mongoid_occurrence_views/event/occurrence.rb
@@ -71,7 +71,6 @@ module MongoidOccurrenceViews
       end
 
       def assign_daily_occurrences
-        return unless dtstart_changed? || dtend_changed? || schedule_changed? || schedule_dtend_changed?
         self.daily_occurrences = daily_occurrences_from_schedule + daily_occurrences_from_date_range
       end
 


### PR DESCRIPTION
This allows the method to be triggered manually, for example when migrating from previous versions etc.

And we already have a check on the callbacks:

```ruby
after_validation :adjust_dates_for_all_day, if: :changed?
after_validation :assign_daily_occurrences, if: :changed?
```