### PR TITLE
Add cascade_callbacks

### DIFF
--- a/lib/mongoid_occurrences/has_occurrences.rb
+++ b/lib/mongoid_occurrences/has_occurrences.rb
@@ -8,7 +8,7 @@ module MongoidOccurrences
       def embeds_many_occurrences(options = {})
         field :_previous_occurrences_cache_key, type: String
 
-        embeds_many :occurrences, class_name: options.fetch(:class_name)
+        embeds_many :occurrences, class_name: options.fetch(:class_name), cascade_callbacks: true
         accepts_nested_attributes_for :occurrences, allow_destroy: true, reject_if: :all_blank
 
         embeds_many :daily_occurrences, class_name: 'MongoidOccurrences::DailyOccurrence', order: :dtstart.asc


### PR DESCRIPTION
We rely on occurrences having their `updated_at` field touched when saving an event, which currently doesn't happen. Adding `cascade_callbacks` fixes that.