### PR TITLE
Fix time zone issue for schedule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 cache: bundler
 script: 'bundle exec rake'
 rvm:
-  - 2.5.1
+  - 2.6.0
 services:
   - mongodb
 
@@ -15,5 +15,5 @@ notifications:
 
 matrix:
   include:
-    - rvm: 2.5.1
+    - rvm: 2.6.0
       env: MONGOID_VERSION=7

--- a/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
+++ b/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
@@ -12,8 +12,8 @@ module MongoidOccurrences
         return [] unless dtstart? && dtend?
         return [] unless recurring?
         schedule.occurrences(schedule_dtend).map do |occurrence|
-          occurrence_dtstart = dtstart.change(day: occurrence.start_time.in_time_zone(Time.zone).day)
-          occurrence_dtend = dtend.change(day: occurrence.end_time.in_time_zone(Time.zone).day)
+          occurrence_dtstart = occurrence.start_time.in_time_zone(Time.zone).change(hour: dtstart.hour, minute: dtstart.minute)
+          occurrence_dtend = occurrence.end_time.in_time_zone(Time.zone).change(hour: dtend.hour, minute: dtend.minute)
 
           build_daily_occurrence(occurrence_dtstart, occurrence_dtend, id, operator)
         end

--- a/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
+++ b/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
@@ -3,9 +3,7 @@ module MongoidOccurrences
     module HasDailyOccurrences
       def daily_occurrences
         adjust_dates_for_all_day!
-
-        daily_occurrences_from_schedule +
-          daily_occurrences_from_date_range
+        daily_occurrences_from_schedule + daily_occurrences_from_date_range
       end
 
       private
@@ -13,14 +11,11 @@ module MongoidOccurrences
       def daily_occurrences_from_schedule
         return [] unless dtstart? && dtend?
         return [] unless recurring?
-
         schedule.occurrences(schedule_dtend).map do |occurrence|
-          MongoidOccurrences::DailyOccurrence.new(
-            dtstart: occurrence.start_time.change(hour: dtstart.hour, min: dtstart.minute),
-            dtend: occurrence.end_time.change(hour: dtend.hour, min: dtend.minute),
-            occurrence_id: id,
-            operator: operator
-          )
+          occurrence_dtstart = dtstart.change(day: occurrence.start_time.in_time_zone(Time.zone).day)
+          occurrence_dtend = dtend.change(day: occurrence.end_time.in_time_zone(Time.zone).day)
+
+          build_daily_occurrence(occurrence_dtstart, occurrence_dtend, id, operator)
         end
       end
 
@@ -32,16 +27,14 @@ module MongoidOccurrences
         is_single_day = (date_range.first == date_range.last)
 
         date_range.map do |date|
-          occurence_dtstart = is_single_day || date == date_range.first ? dtstart : date.beginning_of_day
-          occurence_dtend = is_single_day || date == date_range.last ? dtend : date.end_of_day
-
-          MongoidOccurrences::DailyOccurrence.new(
-            dtstart: occurence_dtstart,
-            dtend: occurence_dtend,
-            occurrence_id: id,
-            operator: operator
-          )
+          occurrence_dtstart = is_single_day || date == date_range.first ? dtstart : date.beginning_of_day
+          occurrence_dtend = is_single_day || date == date_range.last ? dtend : date.end_of_day
+          build_daily_occurrence(occurrence_dtstart, occurrence_dtend, id, operator)
         end
+      end
+
+      def build_daily_occurrence(dtstart, dtend, occurrence_id, operator)
+        MongoidOccurrences::DailyOccurrence.new(dtstart: dtstart, dtend: dtend, occurrence_id: occurrence_id, operator: operator)
       end
     end
   end

--- a/lib/mongoid_occurrences/occurrence/has_schedule.rb
+++ b/lib/mongoid_occurrences/occurrence/has_schedule.rb
@@ -17,7 +17,7 @@ module MongoidOccurrences
 
       def schedule_dtstart
         read_attribute(:schedule_dtstart) ||
-          (dtstart.try(:to_time) || Time.now)
+          (dtstart.try(:to_time) || Time.zone.now)
       end
 
       def schedule_dtend

--- a/lib/mongoid_occurrences/queries/occurs_between.rb
+++ b/lib/mongoid_occurrences/queries/occurs_between.rb
@@ -14,8 +14,8 @@ module MongoidOccurrences
       end
 
       def criteria
-        base_criteria.lte(dtstart_field => adjusted_dtend)
-                     .gte(dtend_field => adjusted_dtstart)
+        base_criteria.lte(dtstart_field => adjusted_dtend.utc)
+                     .gte(dtend_field => adjusted_dtstart.utc)
       end
 
       private

--- a/lib/mongoid_occurrences/queries/occurs_on.rb
+++ b/lib/mongoid_occurrences/queries/occurs_on.rb
@@ -10,7 +10,7 @@ module MongoidOccurrences
       end
 
       def criteria
-        OccursBetween.criteria(base_criteria, adjusted_dtstart, adjusted_dtend, options)
+        OccursBetween.criteria(base_criteria, adjusted_dtstart.utc, adjusted_dtend.utc, options)
       end
 
       private

--- a/lib/mongoid_occurrences/queries/occurs_until.rb
+++ b/lib/mongoid_occurrences/queries/occurs_until.rb
@@ -12,7 +12,7 @@ module MongoidOccurrences
       end
 
       def criteria
-        base_criteria.lte(dtend_field => adjusted_date_time)
+        base_criteria.lte(dtend_field => adjusted_date_time.utc)
       end
 
       private

--- a/test/factories/occurrence.rb
+++ b/test/factories/occurrence.rb
@@ -17,33 +17,33 @@ FactoryBot.define do
     end
 
     trait :today do
-      dtstart { DateTime.now.beginning_of_day + 4.hours }
-      dtend { DateTime.now.beginning_of_day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 4.hours }
+      dtend { Time.zone.now.beginning_of_day + 6.hours }
     end
 
     trait :tomorrow do
-      dtstart { DateTime.now.beginning_of_day + 1.day + 4.hours }
-      dtend { DateTime.now.beginning_of_day + 1.day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 1.day + 4.hours }
+      dtend { Time.zone.now.beginning_of_day + 1.day + 6.hours }
     end
 
     trait :yesterday do
-      dtstart { DateTime.now.beginning_of_day - 1.day + 4.hours }
-      dtend { DateTime.now.beginning_of_day - 1.day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day - 1.day + 4.hours }
+      dtend { Time.zone.now.beginning_of_day - 1.day + 6.hours }
     end
 
     trait :next_week do
-      dtstart { DateTime.now.beginning_of_day + 1.week + 4.hours }
-      dtend { DateTime.now.beginning_of_day + 1.week + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 1.week + 4.hours }
+      dtend { Time.zone.now.beginning_of_day + 1.week + 6.hours }
     end
 
     trait :last_week do
-      dtstart { DateTime.now.beginning_of_day - 1.week + 4.hours }
-      dtend { DateTime.now.beginning_of_day - 1.week + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day - 1.week + 4.hours }
+      dtend { Time.zone.now.beginning_of_day - 1.week + 6.hours }
     end
 
     trait :today_until_tomorrow do
-      dtstart { DateTime.now.beginning_of_day + 4.hours }
-      dtend { DateTime.now.beginning_of_day + 1.day }
+      dtstart { Time.zone.now.beginning_of_day + 4.hours }
+      dtend { Time.zone.now.beginning_of_day + 1.day }
     end
   end
 end

--- a/test/factories/schedule.rb
+++ b/test/factories/schedule.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :schedule, class: IceCube::Schedule do
     trait :daily_for_a_week do
-      start_time { Time.now.beginning_of_day }
+      start_time { Time.zone.now.beginning_of_day }
       after(:build) { |s| s.add_recurrence_rule(IceCube::Rule.daily(1).count(7)) }
     end
   end

--- a/test/mongoid_occurrences/daily_occurrence_test.rb
+++ b/test/mongoid_occurrences/daily_occurrence_test.rb
@@ -18,7 +18,7 @@ describe MongoidOccurrences::DailyOccurrence do
     end
 
     describe '#all_day' do
-      let(:daily_occurrence) { build :daily_occurrence, dtstart: Time.now.beginning_of_day, dtend: Time.now.end_of_day }
+      let(:daily_occurrence) { build :daily_occurrence, dtstart: Time.zone.now.beginning_of_day, dtend: Time.zone.now.end_of_day }
 
       it { daily_occurrence.must_be :all_day }
       it { daily_occurrence.must_be :all_day? }

--- a/test/mongoid_occurrences/has_occurrences_test.rb
+++ b/test/mongoid_occurrences/has_occurrences_test.rb
@@ -27,8 +27,8 @@ describe MongoidOccurrences::HasOccurrences do
   end
 
   describe '#occurrences_cache_key' do
-    let(:occurrence_1) { build :occurrence, :today, updated_at: Time.now - 1.day }
-    let(:occurrence_2) { build :occurrence, :tomorrow, updated_at: Time.now }
+    let(:occurrence_1) { build :occurrence, :today, updated_at: Time.zone.now - 1.day }
+    let(:occurrence_2) { build :occurrence, :tomorrow, updated_at: Time.zone.now }
     let(:event) { build :event, occurrences: [occurrence_1, occurrence_2] }
 
     it { event.occurrences_cache_key.must_equal "2-#{occurrence_2.updated_at.to_i}" }

--- a/test/mongoid_occurrences/occurrence/has_operators_test.rb
+++ b/test/mongoid_occurrences/occurrence/has_operators_test.rb
@@ -24,8 +24,8 @@ describe MongoidOccurrences::Occurrence::HasOperators do
   end
 
   describe ':replace' do
-    let(:dtstart) { DateTime.now.beginning_of_day + 1.day + 1.hour }
-    let(:dtend) { DateTime.now.beginning_of_day + 1.day + 11.hours }
+    let(:dtstart) { Time.zone.now.beginning_of_day + 1.day + 1.hour }
+    let(:dtend) { Time.zone.now.beginning_of_day + 1.day + 11.hours }
 
     let(:occurrence_1) { build :occurrence, :append, :today, schedule: build(:schedule, :daily_for_a_week) }
     let(:occurrence_2) { build :occurrence, :replace, :tomorrow, dtstart: dtstart, dtend: dtend }

--- a/test/mongoid_occurrences/occurrence/has_schedule_test.rb
+++ b/test/mongoid_occurrences/occurrence/has_schedule_test.rb
@@ -7,8 +7,8 @@ describe MongoidOccurrences::Occurrence::HasSchedule do
   it { occurrence.must_respond_to :schedule_dtstart }
   it { occurrence.must_respond_to :schedule_dtend }
 
-  it { occurrence.schedule_dtstart.to_i.must_equal Time.now.to_i }
-  it { occurrence.schedule_dtend.to_i.must_equal (Time.now + MongoidOccurrences::Occurrence::HasSchedule::SCHEDULE_DURATION).to_i }
+  it { occurrence.schedule_dtstart.to_i.must_equal Time.zone.now.to_i }
+  it { occurrence.schedule_dtend.to_i.must_equal (Time.zone.now + MongoidOccurrences::Occurrence::HasSchedule::SCHEDULE_DURATION).to_i }
 
   describe 'nil_schedule' do
     let(:occurrence) { build :occurrence, :today }

--- a/test/mongoid_occurrences/occurrence_test.rb
+++ b/test/mongoid_occurrences/occurrence_test.rb
@@ -14,7 +14,7 @@ describe MongoidOccurrences::Occurrence do
   it { occurrence.must_respond_to :updated_at }
 
   describe 'all_day' do
-    let(:occurrence) { build :occurrence, :today, dtstart: DateTime.now.beginning_of_day, dtend: DateTime.now.end_of_day }
+    let(:occurrence) { build :occurrence, :today, dtstart: Time.zone.now.beginning_of_day, dtend: Time.zone.now.end_of_day }
 
     it { occurrence.must_be :all_day }
     it { occurrence.must_be :all_day? }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,6 +14,8 @@ require 'active_support/core_ext/time'
 
 require 'mongoid_occurrences'
 
+Time.zone = 'Copenhagen'
+
 Mongoid.configure do |config|
   config.connect_to('mongoid_occurrences__test')
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,7 +14,7 @@ require 'active_support/core_ext/time'
 
 require 'mongoid_occurrences'
 
-Time.zone = 'Copenhagen'
+Time.zone = 'Hawaii'
 
 Mongoid.configure do |config|
   config.connect_to('mongoid_occurrences__test')


### PR DESCRIPTION
When expanding a schedule to daily occurrences `dtstart` and `dtend` are messed up.

This is caused by changing `start_time` and `end_time` from the `IceCube` schedule cast in UTC with the `dtstart` and `dtend`fields which are are cast in the time zone of the app.

This fix solves the issue and cleans up the code slightly.