### PR TITLE
Fix missing minutes when creating daily occurrences from a schedule (rebased)

### DIFF
--- a/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
+++ b/lib/mongoid_occurrences/occurrence/has_daily_occurrences.rb
@@ -12,8 +12,8 @@ module MongoidOccurrences
         return [] unless dtstart? && dtend?
         return [] unless recurring?
         schedule.occurrences(schedule_dtend).map do |occurrence|
-          occurrence_dtstart = occurrence.start_time.in_time_zone(Time.zone).change(hour: dtstart.hour, minute: dtstart.minute)
-          occurrence_dtend = occurrence.end_time.in_time_zone(Time.zone).change(hour: dtend.hour, minute: dtend.minute)
+          occurrence_dtstart = occurrence.start_time.in_time_zone(Time.zone).change(hour: dtstart.hour, min: dtstart.minute)
+          occurrence_dtend = occurrence.end_time.in_time_zone(Time.zone).change(hour: dtend.hour, min: dtend.minute)
 
           build_daily_occurrence(occurrence_dtstart, occurrence_dtend, id, operator)
         end

--- a/test/factories/occurrence.rb
+++ b/test/factories/occurrence.rb
@@ -17,23 +17,23 @@ FactoryBot.define do
     end
 
     trait :today do
-      dtstart { Time.zone.now.beginning_of_day + 4.hours }
-      dtend { Time.zone.now.beginning_of_day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 4.hours + 30.minutes }
+      dtend { Time.zone.now.beginning_of_day + 6.hours + 45.minutes }
     end
 
     trait :tomorrow do
-      dtstart { Time.zone.now.beginning_of_day + 1.day + 4.hours }
-      dtend { Time.zone.now.beginning_of_day + 1.day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 1.day + 4.hours + 30.minutes }
+      dtend { Time.zone.now.beginning_of_day + 1.day + 6.hours + 45.minutes }
     end
 
     trait :yesterday do
-      dtstart { Time.zone.now.beginning_of_day - 1.day + 4.hours }
-      dtend { Time.zone.now.beginning_of_day - 1.day + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day - 1.day + 4.hours + 30.minutes }
+      dtend { Time.zone.now.beginning_of_day - 1.day + 6.hours + 45.minutes }
     end
 
     trait :next_week do
-      dtstart { Time.zone.now.beginning_of_day + 1.week + 4.hours }
-      dtend { Time.zone.now.beginning_of_day + 1.week + 6.hours }
+      dtstart { Time.zone.now.beginning_of_day + 1.week + 4.hours + 30.minutes }
+      dtend { Time.zone.now.beginning_of_day + 1.week + 6.hours + 45.minutes }
     end
 
     trait :last_week do


### PR DESCRIPTION
Minutes were not included when creating daily occurrences from a schedule.

The cause was the use of a wrongly named parameter in the `change` method: `minute` should have been `min` 😢